### PR TITLE
Implement BigQuery sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ in the Cloud Console.
    ```
 1. Create a custom role with required permissions for accessing DLP, Dataflow and KMS:
    ```shell script
-   export TOKENIZING_ROLE_NAME="tokenizing_runner"
+   export TOKENIZING_ROLE_NAME="tokenizing_runner2"
 
    gcloud iam roles create ${TOKENIZING_ROLE_NAME} \
    --project=${PROJECT_ID} \
@@ -304,8 +304,8 @@ sample_and_identify_pipeline --project="${PROJECT_ID}" \
 --stagingLocation="gs://${TEMP_GCS_BUCKET}/staging" \
 --workerMachineType="n1-standard-1" \
 --sampleSize=500 \
---fileType="AVRO" \
---inputFilePattern="gs://${TEMP_GCS_BUCKET}/userdata.avro" \
+--sourceType="AVRO" \
+--inputPattern="gs://${TEMP_GCS_BUCKET}/userdata.avro" \
 --reportLocation="gs://${TEMP_GCS_BUCKET}/dlp_report/"
 ```
 
@@ -379,8 +379,8 @@ tokenize_pipeline --project="${PROJECT_ID}" \
 --schema="$(<dlp_report/schema.json)" \
 --tinkEncryptionKeySetJson="$(<${WRAPPED_KEY_FILE})" \
 --mainKmsKeyUri="${MAIN_KMS_KEY_URI}" \
---fileType="AVRO" \
---inputFilePattern="gs://${TEMP_GCS_BUCKET}/userdata.avro" \
+--sourceType="AVRO" \
+--inputPattern="gs://${TEMP_GCS_BUCKET}/userdata.avro" \
 --outputDirectory="gs://${TEMP_GCS_BUCKET}/encrypted/" \
 --tokenizeColumns="$.kylosample.cc" \
 --tokenizeColumns="$.kylosample.email"

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
@@ -18,6 +18,7 @@ package com.google.cloud.solutions.autotokenize.common;
 
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.io.gcp.bigquery.SchemaAndRecord;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 
@@ -39,9 +40,21 @@ public interface FlatRecordConvertFn<T> extends SerializableFunction<T, KV<FlatR
     private GenericRecordFlatteningFn() {}
   }
 
+  final class TableRowFlatteningFn implements FlatRecordConvertFn<SchemaAndRecord> {
+
+    private static TableRowFlatteningFn tableRowFlatteningFn = new TableRowFlatteningFn();
+
+    @Override
+    public KV<FlatRecord, String> apply(SchemaAndRecord input) {
+      return KV.of(RecordFlattener.forGenericRecord().flatten(input.getRecord()), input.getRecord().getSchema().toString());
+    }
+
+    private TableRowFlatteningFn() {}
+  }
+
   static GenericRecordFlatteningFn forGenericRecord() {
     return GenericRecordFlatteningFn.genericRecordFlatteningFn;
   }
 
-
+  static TableRowFlatteningFn forBigQueryTableRow() { return TableRowFlatteningFn.tableRowFlatteningFn;}
 }

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.solutions.autotokenize.common;
 
-import static com.google.cloud.solutions.autotokenize.common.RecordFlattener.flattenGenericRecord;
+import static com.google.cloud.solutions.autotokenize.common.GenericRecordFlattener.flattenGenericRecord;
 
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
 import org.apache.avro.generic.GenericRecord;
@@ -26,18 +26,24 @@ import org.apache.beam.sdk.values.KV;
 /**
  * Flattens a GenericRecord and separates the Avro schema as a KV.
  */
-public class FlatRecordConvertFn implements
-    SerializableFunction<GenericRecord, KV<FlatRecord, String>> {
+public interface FlatRecordConvertFn<T> extends SerializableFunction<T, KV<FlatRecord, String>> {
 
-  @Override
-  public KV<FlatRecord, String> apply(GenericRecord record) {
-    return KV.of(flattenGenericRecord(record), record.getSchema().toString());
+
+  final class GenericRecordFlatteningFn implements FlatRecordConvertFn<GenericRecord> {
+
+    private static GenericRecordFlatteningFn genericRecordFlatteningFn = new GenericRecordFlatteningFn();
+
+    @Override
+    public KV<FlatRecord, String> apply(GenericRecord record) {
+      return KV.of(flattenGenericRecord(record), record.getSchema().toString());
+    }
+
+    private GenericRecordFlatteningFn() {}
   }
 
-  public static FlatRecordConvertFn create() {
-    return new FlatRecordConvertFn();
+  static GenericRecordFlatteningFn forGenericRecord() {
+    return GenericRecordFlatteningFn.genericRecordFlatteningFn;
   }
 
-  private FlatRecordConvertFn() {
-  }
+
 }

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/FlatRecordConvertFn.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.solutions.autotokenize.common;
 
-import static com.google.cloud.solutions.autotokenize.common.GenericRecordFlattener.flattenGenericRecord;
-
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -35,7 +33,7 @@ public interface FlatRecordConvertFn<T> extends SerializableFunction<T, KV<FlatR
 
     @Override
     public KV<FlatRecord, String> apply(GenericRecord record) {
-      return KV.of(flattenGenericRecord(record), record.getSchema().toString());
+      return KV.of(RecordFlattener.forGenericRecord().flatten(record), record.getSchema().toString());
     }
 
     private GenericRecordFlatteningFn() {}

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattener.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattener.java
@@ -46,7 +46,7 @@ import org.apache.avro.generic.GenericRecord;
  * {string_value: "work"}, $.contacts[1].contact.number -> {string_value: "987-654-321"} }
  * </code>
  */
-public final class RecordFlattener {
+public final class GenericRecordFlattener {
 
   public static final String RECORD_ROOT_SYMBOL = "$";
 

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattener.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattener.java
@@ -46,7 +46,7 @@ import org.apache.avro.generic.GenericRecord;
  * {string_value: "work"}, $.contacts[1].contact.number -> {string_value: "987-654-321"} }
  * </code>
  */
-public final class GenericRecordFlattener {
+public final class GenericRecordFlattener implements RecordFlattener<GenericRecord>{
 
   public static final String RECORD_ROOT_SYMBOL = "$";
 
@@ -55,7 +55,8 @@ public final class GenericRecordFlattener {
    *
    * @param record the AVRO record to flatten.
    */
-  public static FlatRecord flattenGenericRecord(GenericRecord record) {
+  @Override
+  public FlatRecord flatten(GenericRecord record) {
     return new TypeFlattener(record).convert();
   }
 

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/RecordFlattener.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/RecordFlattener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.common;
+
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
+
+public interface RecordFlattener<T> {
+
+  FlatRecord flatten(T nestedRecord);
+
+  static GenericRecordFlattener forGenericRecord() {
+    return new GenericRecordFlattener();
+  }
+}

--- a/common/src/main/java/com/google/cloud/solutions/autotokenize/common/SourceNames.java
+++ b/common/src/main/java/com/google/cloud/solutions/autotokenize/common/SourceNames.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.SourceType;
+import org.apache.commons.text.CaseUtils;
+
+public final class SourceNames {
+
+  private final SourceType sourceType;
+
+  public static SourceNames forType(SourceType sourceType) {
+    return new SourceNames(sourceType);
+  }
+
+  private SourceNames(SourceType sourceType) {
+    this.sourceType = checkNotNull(sourceType);
+  }
+
+  public String asCamelCase() {
+    return CaseUtils.toCamelCase(sourceType.name(), /*capitalizeFirstLetter=*/ true, '_');
+  }
+
+  @Override
+  public String toString() {
+    return sourceType.name();
+  }
+}

--- a/common/src/test/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattenerTest.java
+++ b/common/src/test/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattenerTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.solutions.autotokenize.common;
 
-import static com.google.cloud.solutions.autotokenize.common.RecordFlattener.flattenGenericRecord;
+import static com.google.cloud.solutions.autotokenize.common.GenericRecordFlattener.flattenGenericRecord;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Enclosed.class)
-public final class RecordFlattenerTest {
+public final class GenericRecordFlattenerTest {
 
   @RunWith(Parameterized.class)
   public static final class ValidInputOutputTests {

--- a/common/src/test/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattenerTest.java
+++ b/common/src/test/java/com/google/cloud/solutions/autotokenize/common/GenericRecordFlattenerTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.solutions.autotokenize.common;
 
-import static com.google.cloud.solutions.autotokenize.common.GenericRecordFlattener.flattenGenericRecord;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -94,7 +93,7 @@ public final class GenericRecordFlattenerTest {
           .withSchemaFile(avroSchemaJsonFile)
           .loadRecord(avroRecordJsonFile);
 
-      FlatRecord flatRecord = flattenGenericRecord(testRecord);
+      FlatRecord flatRecord = new GenericRecordFlattener().flatten(testRecord);
 
       assertThat(flatRecord)
           .isEqualTo(
@@ -159,7 +158,7 @@ public final class GenericRecordFlattenerTest {
           assertThrows(
               exceptionClass,
               () ->
-                  flattenGenericRecord(
+                new GenericRecordFlattener().flatten(
                       TestResourceLoader.classPath()
                           .forAvro()
                           .withSchemaFile(avroSchemaJsonFile)

--- a/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptingPipelineOptions.java
+++ b/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptingPipelineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.google.cloud.solutions.autotokenize.pipeline;
 
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages;
 import java.util.List;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.Validation.Required;
@@ -26,14 +27,14 @@ import org.apache.beam.sdk.options.Validation.Required;
 public interface EncryptingPipelineOptions extends GcpOptions {
 
   @Required
-  String getFileType();
+  AutoTokenizeMessages.SourceType getSourceType();
 
-  void setFileType(String fileType);
+  void setSourceType(AutoTokenizeMessages.SourceType fileType);
 
   @Required
-  String getInputFilePattern();
+  String getInputPattern();
 
-  void setInputFilePattern(String inputFilePattern);
+  void setInputPattern(String inputPattern);
 
   @Required
   String getSchema();

--- a/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptionPipeline.java
+++ b/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptionPipeline.java
@@ -110,7 +110,7 @@ public class EncryptionPipeline {
           .apply("Read" + options.getFileType(),
               TransformingFileReader
                   .forFileType(options.getFileType())
-                  .withInputFilePattern(options.getInputFilePattern())
+                  .from(options.getInputFilePattern())
                   .withRecordsTag(flatRecordsTag))
           .get(flatRecordsTag)
           .apply("EncryptRecords",

--- a/encrypting-pipeline/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/ValueEncryptionTransformTest.java
+++ b/encrypting-pipeline/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/ValueEncryptionTransformTest.java
@@ -138,7 +138,7 @@ public final class ValueEncryptionTransformTest {
                 MapElements
                     .into(TypeDescriptors
                         .kvs(TypeDescriptor.of(FlatRecord.class), TypeDescriptor.of(String.class)))
-                    .via(FlatRecordConvertFn.create()))
+                    .via(FlatRecordConvertFn.forGenericRecord()))
             .apply(Keys.create())
             .apply(
                 "test_encrypt_transform",

--- a/proto-messages/src/main/resources/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+++ b/proto-messages/src/main/resources/proto/google/cloud/autodlp/auto_tokenize_messages.proto
@@ -32,10 +32,12 @@ message DlpReport {
 }
 
 // The supported file types.
-enum FileType {
+enum SourceType {
   UNKNOWN_FILE_TYPE = 0;
   AVRO = 1;
   PARQUET = 2;
+  BIGQUERY_TABLE = 3;
+  BIGQUERY_QUERY = 4;
 }
 
 // The information types associated with each column of the input structured file.

--- a/sampler-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpSamplerIdentifyOptions.java
+++ b/sampler-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpSamplerIdentifyOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,14 @@ public interface DlpSamplerIdentifyOptions extends GcpOptions {
   void setSampleSize(int sampleSize);
 
   @Validation.Required
-  AutoTokenizeMessages.FileType getFileType();
+  AutoTokenizeMessages.SourceType getSourceType();
 
-  void setFileType(AutoTokenizeMessages.FileType fileType);
+  void setSourceType(AutoTokenizeMessages.SourceType fileType);
 
   @Validation.Required
-  String getInputFilePattern();
+  String getInputPattern();
 
-  void setInputFilePattern(String inputFilePattern);
+  void setInputPattern(String inputFilePattern);
 
   @Validation.Required
   String getReportLocation();

--- a/sampler-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpSamplerIdentifyPipeline.java
+++ b/sampler-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpSamplerIdentifyPipeline.java
@@ -69,7 +69,7 @@ public final class DlpSamplerIdentifyPipeline {
             .apply("Read" + options.getFileType().name(),
                 TransformingFileReader
                     .forFileType(options.getFileType().name())
-                    .withInputFilePattern(options.getInputFilePattern())
+                    .from(options.getInputFilePattern())
                     .withRecordsTag(recordsTag)
                     .withAvroSchemaTag(avroSchemaTag));
 

--- a/tokenizing_runner_permissions.yaml
+++ b/tokenizing_runner_permissions.yaml
@@ -21,6 +21,26 @@ includedPermissions:
   # DLP permissions
   - serviceusage.services.use
   - dlp.kms.encrypt
+  # BigQuery permissions
+  - bigquery.jobs.create
+  - bigquery.jobs.get
+  - bigquery.jobs.list
+  - bigquery.jobs.listAll
+  - bigquery.jobs.update
+  - bigquery.tables.get
+  - bigquery.tables.create
+  - bigquery.tables.getIamPolicy
+  - bigquery.tables.setIamPolicy
+  - bigquery.tables.getData
+  - bigquery.tables.list
+  - bigquery.tables.export
+  - bigquery.datasets.get
+  - bigquery.datasets.create
+  - bigquery.datasets.getIamPolicy
+  - bigquery.datasets.setIamPolicy
+  - bigquery.readsessions.create
+  - bigquery.readsessions.getData
+  - bigquery.readsessions.update
   # Dataflow permissions
   - compute.instanceGroupManagers.update
   - compute.instances.delete


### PR DESCRIPTION
Fixes #2 
Added BigQuery **Table** and **Query** as additional sources.
The value of `inputPattern` is governed as follows
 *  `BIGQUERY_TABLE`: Legacy format table spec, e.g. `<project_id>**:**<dataset_id>**.**<table_id>`
 *  `BIGQUERY_QUERY`: SQL statement in StandardSQL format.
