### PR TITLE
 Support BigQuery table as destination for tokenized output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,16 @@ sample_and_identify_pipeline --project="${PROJECT_ID}" \
 --reportLocation="gs://${TEMP_GCS_BUCKET}/dlp_report/"
 ```
 
-The pipeline detects all the standard infotypes supported by DLP.
+The pipeline supports multiple **Source Types**, use the following table to use the right combination of `sourceType` and `inputPattern` arguments.
+
+| Data source | sourceType | inputPattern |
+| --- | --- | --- |
+| **Avro** file in Cloud Storage  | `AVRO` | `gs://<location of the file(s)` |
+| **Parquet** file in Cloud Storage  | `PARQUET` | `gs://<location of the file(s)` |
+| BigQuery table   | `BIGQUERY_TABLE` | `<project-id>:<dataset>.<table>` |
+| Query results in BigQuery | `BIGQUERY_QUERY` | BigQuery SQL statement in StandardSQL dialect. |
+
+The pipeline detects all the [standard infotypes](https://cloud.google.com/dlp/docs/infotypes-reference) supported by DLP.
 Use `--observableInfoTypes` to provide additional custom info-types that you need.
 
 ### Sample & Identify pipeline DAG
@@ -387,6 +396,14 @@ tokenize_pipeline --project="${PROJECT_ID}" \
 --tokenizeColumns="$.kylosample.cc" \
 --tokenizeColumns="$.kylosample.email"
 ```
+
+The pipeline supports following destinations for storing the tokenized output.
+
+| Destination | Description | Pipeline parameter |
+| --- | --- | --- |
+| File in Cloud Storage  | Stores as an AVRO file | `--outputDirectory=gs://<location of the directory/` |
+| BigQuery table | uses `WRITE_TRUNCATE` mode to write results to a BigQuery Table. | `--outputBigQueryTable=<project-id>:<dataset>.<table>` |
+You can use one or both of them simultaneously.
 
 The pipeline executes asynchronously on Dataflow. You can check the progress by following the JobLink printed in the following format:
 ```

--- a/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptingPipelineOptions.java
+++ b/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/EncryptingPipelineOptions.java
@@ -46,10 +46,13 @@ public interface EncryptingPipelineOptions extends GcpOptions {
 
   void setTokenizeColumns(List<String> fileDlpReportJson);
 
-  @Required
   String getOutputDirectory();
 
   void setOutputDirectory(String outputFilePattern);
+
+  String getOutputBigQueryTable();
+
+  void setOutputBigQueryTable(String outputBigQueryTable);
 
   @Required
   String getTinkEncryptionKeySetJson();

--- a/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/ValueEncryptionTransform.java
+++ b/encrypting-pipeline/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/ValueEncryptionTransform.java
@@ -24,7 +24,7 @@ import com.google.cloud.solutions.autotokenize.pipeline.encryptors.EncryptingFla
 import com.google.common.collect.ImmutableSet;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SimpleFunction;
@@ -61,7 +61,7 @@ public abstract class ValueEncryptionTransform
                     .withTokenizerFactory(valueTokenizerFactory())
                     .encryptFn()))
         .apply("NestAsGenericRecord", MapElements.via(new RecordNester(encryptedSchemaJson())))
-        .setCoder(AvroCoder.of(new Schema.Parser().parse(encryptedSchemaJson())));
+        .setCoder(AvroUtils.schemaCoder(GenericRecord.class, new Schema.Parser().parse(encryptedSchemaJson())));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <auto-value.version>1.7.4</auto-value.version>
     <autotokenize.version>0.1-SNAPSHOT</autotokenize.version>
     <avro.version>1.10.1</avro.version>
-    <beam.version>2.26.0</beam.version>
+    <beam.version>2.27.0</beam.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <flogger.version>0.5.1</flogger.version>
     <guava.version>29.0-jre</guava.version>


### PR DESCRIPTION
 Use Beam schemas to define output BigQuery table schema.
Update README with instructions on using BigQuery tables as destination.