### PR TITLE
Handle updated DLP array parameter in DeidentifyConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The encryption pipeline supports two encryption modes:
     <tr>
       <td>DLP De-identify</td>
 <td><code>--dlpEncryptConfigJson</code></td>
-<td><a href="proto-messages/src/main/resources/proto/google/cloud/autodlp/auto_tokenize_messages.proto">DlpEncryptConfig</a>
+<td><a href="protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto">DlpEncryptConfig</a>
 JSON to provide <a href="https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#DeidentifyTemplate.PrimitiveTransformation">PrimitiveTransformation</a>
 for each <code>tokenizedColumn</code>.
 <br>

--- a/dlp/build.gradle
+++ b/dlp/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(":common")
     implementation "com.google.cloud:google-cloud-dlp:${dlpClientVersion}"
 
+    testImplementation project(":common-util")
     testImplementation project(":test-util")
 }
 

--- a/dlp/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/dlp/BatchAndDlpDeIdRecordsTest.java
+++ b/dlp/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/dlp/BatchAndDlpDeIdRecordsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.pipeline.dlp;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.ColumnTransform;
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.DlpEncryptConfig;
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
+import com.google.cloud.solutions.autotokenize.common.RecordFlattener;
+import com.google.cloud.solutions.autotokenize.testing.TestResourceLoader;
+import com.google.cloud.solutions.autotokenize.testing.stubs.dlp.Base64EncodingDlpStub;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.extensions.proto.ProtoTruth;
+import com.google.privacy.dlp.v2.CryptoDeterministicConfig;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.UnwrappedCryptoKey;
+import com.google.protobuf.ByteString;
+import java.io.Serializable;
+import java.util.Base64;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BatchAndDlpDeIdRecordsTest {
+
+  @Rule public transient TestPipeline testPipeline = TestPipeline.create();
+
+  @Test
+  public void expand_valid() {
+
+    ImmutableList<FlatRecord> expectedBase64EncodedContacts =
+        TestResourceLoader.classPath()
+            .forProto(FlatRecord.class)
+            .loadAllTextFiles(
+                ImmutableList.of(
+                    "avro_records/contacts_schema/jane_doe_contact_number_base64_avro_record.textpb",
+                    "avro_records/contacts_schema/john_doe_contact_number_base64_avro_record.textpb"));
+
+    PCollection<FlatRecord> tokenizedRecords =
+        testPipeline
+            .apply(Create.of(CONTACT_RECORDS))
+            .apply(
+                BatchAndDlpDeIdRecords.withEncryptConfig(NUMBER_TOKENIZE_CONFIG)
+                    .withDlpProjectId("dlp-test-project")
+                    .withDlpClientFactory(
+                        DlpClientFactory.withStub(
+                            new Base64EncodingDlpStub(
+                                PartialColumnBatchAccumulator.RECORD_ID_COLUMN_NAME,
+                                ImmutableList.of(
+                                    "$.contacts[1].[\"contact\"].number",
+                                    "$.contacts[0].[\"contact\"].number"),
+                                "dlp-test-project"))));
+
+    PAssert.that(tokenizedRecords)
+        .satisfies(new FlatRecordCheckerWithoutRecordIds(expectedBase64EncodedContacts));
+    testPipeline.run().waitUntilFinish();
+  }
+
+  private static final class FlatRecordCheckerWithoutRecordIds
+      extends SimpleFunction<Iterable<FlatRecord>, Void> implements Serializable {
+
+    private final ImmutableList<FlatRecord> expectedRecords;
+
+    public FlatRecordCheckerWithoutRecordIds(ImmutableList<FlatRecord> expectedRecords) {
+      this.expectedRecords = expectedRecords;
+    }
+
+    @Override
+    public Void apply(Iterable<FlatRecord> input) {
+
+      ProtoTruth.assertThat(input)
+          .ignoringFields(FlatRecord.RECORD_ID_FIELD_NUMBER)
+          .containsExactlyElementsIn(expectedRecords);
+      return null;
+    }
+  }
+
+  private static final ImmutableList<FlatRecord> CONTACT_RECORDS =
+      TestResourceLoader.classPath()
+          .forAvro()
+          .withSchemaFile(
+              "avro_records/contacts_schema/person_name_union_null_long_contact_schema.json")
+          .loadAllRecords(
+              "avro_records/contacts_schema/john_doe_contact_plain_avro_record.json",
+              "avro_records/contacts_schema/jane_doe_contact_plain_avro_record.json")
+          .stream()
+          .map(RecordFlattener.forGenericRecord()::flatten)
+          .collect(toImmutableList());
+
+  private static final FlatRecord JANE_DOE_CONTACT =
+      RecordFlattener.forGenericRecord()
+          .flatten(
+              TestResourceLoader.classPath()
+                  .forAvro()
+                  .withSchemaFile(
+                      "avro_records/contacts_schema/person_name_union_null_long_contact_schema.json")
+                  .loadRecord(
+                      "avro_records/contacts_schema/jane_doe_contact_plain_avro_record.json"));
+
+  private static final PrimitiveTransformation CRYPTO_UNWRAPPED_TRANSFORM =
+      PrimitiveTransformation.newBuilder()
+          .setCryptoDeterministicConfig(
+              CryptoDeterministicConfig.newBuilder()
+                  .setCryptoKey(
+                      CryptoKey.newBuilder()
+                          .setUnwrapped(
+                              UnwrappedCryptoKey.newBuilder()
+                                  .setKey(
+                                      ByteString.copyFrom(
+                                          Base64.getDecoder()
+                                              .decode(
+                                                  "QiZFKUhATWNRZlRqV21acTR0N3cheiVDKkYtSmFOZFI="))))))
+          .build();
+
+  private static final DlpEncryptConfig NUMBER_TOKENIZE_CONFIG =
+      DlpEncryptConfig.newBuilder()
+          .addTransforms(
+              ColumnTransform.newBuilder()
+                  .setColumnId("$.contact_records.contacts.contact.number")
+                  .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+          .build();
+}

--- a/dlp/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/dlp/PartialColumnBatchAccumulatorTest.java
+++ b/dlp/src/test/java/com/google/cloud/solutions/autotokenize/pipeline/dlp/PartialColumnBatchAccumulatorTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.pipeline.dlp;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.ColumnTransform;
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.DlpEncryptConfig;
+import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
+import com.google.cloud.solutions.autotokenize.common.DeidentifyColumns;
+import com.google.cloud.solutions.autotokenize.common.RecordFlattener;
+import com.google.cloud.solutions.autotokenize.pipeline.dlp.PartialColumnBatchAccumulator.BatchPartialColumnDlpTable;
+import com.google.cloud.solutions.autotokenize.testing.TestResourceLoader;
+import com.google.common.collect.ImmutableList;
+import com.google.privacy.dlp.v2.CryptoDeterministicConfig;
+import com.google.privacy.dlp.v2.CryptoKey;
+import com.google.privacy.dlp.v2.FieldId;
+import com.google.privacy.dlp.v2.FieldTransformation;
+import com.google.privacy.dlp.v2.PrimitiveTransformation;
+import com.google.privacy.dlp.v2.UnwrappedCryptoKey;
+import com.google.privacy.dlp.v2.Value;
+import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PartialColumnBatchAccumulatorTest {
+
+  private static final ImmutableList<FlatRecord> CONTACT_RECORDS =
+      TestResourceLoader.classPath()
+          .forAvro()
+          .withSchemaFile(
+              "avro_records/contacts_schema/person_name_union_null_long_contact_schema.json")
+          .loadAllRecords(
+              "avro_records/contacts_schema/john_doe_contact_plain_avro_record.json",
+              "avro_records/contacts_schema/jane_doe_contact_plain_avro_record.json")
+          .stream()
+          .map(RecordFlattener.forGenericRecord()::flatten)
+          .collect(toImmutableList());
+
+  private static final FlatRecord JANE_DOE_CONTACT =
+      RecordFlattener.forGenericRecord()
+          .flatten(
+              TestResourceLoader.classPath()
+                  .forAvro()
+                  .withSchemaFile(
+                      "avro_records/contacts_schema/person_name_union_null_long_contact_schema.json")
+                  .loadRecord(
+                      "avro_records/contacts_schema/jane_doe_contact_plain_avro_record.json"));
+
+  private static final PrimitiveTransformation CRYPTO_UNWRAPPED_TRANSFORM =
+      PrimitiveTransformation.newBuilder()
+          .setCryptoDeterministicConfig(
+              CryptoDeterministicConfig.newBuilder()
+                  .setCryptoKey(
+                      CryptoKey.newBuilder()
+                          .setUnwrapped(
+                              UnwrappedCryptoKey.newBuilder()
+                                  .setKey(
+                                      ByteString.copyFrom(
+                                          Base64.getDecoder()
+                                              .decode(
+                                                  "QiZFKUhATWNRZlRqV21acTR0N3cheiVDKkYtSmFOZFI="))))))
+          .build();
+
+  private static final DlpEncryptConfig NUMBER_TOKENIZE_CONFIG =
+      DlpEncryptConfig.newBuilder()
+          .addTransforms(
+              ColumnTransform.newBuilder()
+                  .setColumnId("$.contact_records.contacts.contact.number")
+                  .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+          .build();
+
+  @Test
+  public void addElement_noRecordId_throwsIllegalArgumentExecption() {
+    PartialColumnBatchAccumulator accumulator =
+        PartialColumnBatchAccumulator.withConfig(NUMBER_TOKENIZE_CONFIG);
+
+    assertThrows(IllegalArgumentException.class, () -> accumulator.addElement(JANE_DOE_CONTACT));
+  }
+
+  @Test
+  public void batch_arrayFields_deidConfigContainsOnlyFieldReference() {
+    PartialColumnBatchAccumulator accumulator =
+        PartialColumnBatchAccumulator.withConfig(
+            DlpEncryptConfig.newBuilder()
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId("$.multi_level_arrays.simple_field1")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId(
+                            "$.multi_level_arrays.level1_array.level1_array_record.level2_simple_field")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId(
+                            "$.multi_level_arrays.level1_array.level1_array_record.level2_array")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .build());
+
+    FlatRecord record =
+        RecordFlattener.forGenericRecord()
+            .flatten(
+                TestResourceLoader.classPath()
+                    .forAvro()
+                    .withSchemaFile(
+                        "avro_records/records_with_two_levels_of_arrays/two_level_arrays_schema.avsc")
+                    .loadRecord(
+                        "avro_records/records_with_two_levels_of_arrays/simple_two_level_array_record.json"));
+
+    accumulator.addElement(record.toBuilder().setRecordId(UUID.randomUUID().toString()).build());
+
+    BatchPartialColumnDlpTable batch = accumulator.makeBatch();
+
+    ImmutableList<FieldId> deidConfigTokenizeFields =
+        batch
+            .get()
+            .getDeidentifyConfig()
+            .getRecordTransformations()
+            .getFieldTransformationsList()
+            .stream()
+            .map(FieldTransformation::getFieldsList)
+            .flatMap(List::stream)
+            .collect(toImmutableList());
+
+    assertThat(deidConfigTokenizeFields)
+        .containsExactlyElementsIn(
+            DeidentifyColumns.fieldIdsFor(
+                ImmutableList.of(
+                    "$.simple_field1",
+                    "$.level1_array.[\"level1_array_record\"].level2_simple_field.string",
+                    "$.level1_array.[\"level1_array_record\"].level2_array.string")));
+  }
+
+  @Test
+  public void batch_arrayFields_itemTableContainsFlattenedEntries() {
+    PartialColumnBatchAccumulator accumulator =
+        PartialColumnBatchAccumulator.withConfig(
+            DlpEncryptConfig.newBuilder()
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId("$.multi_level_arrays.simple_field1")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId(
+                            "$.multi_level_arrays.level1_array.level1_array_record.level2_simple_field")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId(
+                            "$.multi_level_arrays.level1_array.level1_array_record.level2_array")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM))
+                .build());
+
+    FlatRecord record =
+        RecordFlattener.forGenericRecord()
+            .flatten(
+                TestResourceLoader.classPath()
+                    .forAvro()
+                    .withSchemaFile(
+                        "avro_records/records_with_two_levels_of_arrays/two_level_arrays_schema.avsc")
+                    .loadRecord(
+                        "avro_records/records_with_two_levels_of_arrays/simple_two_level_array_record.json"));
+
+    accumulator.addElement(record.toBuilder().setRecordId(UUID.randomUUID().toString()).build());
+
+    BatchPartialColumnDlpTable batch = accumulator.makeBatch();
+
+    assertThat(batch.get().getTable().getHeadersList())
+        .containsExactlyElementsIn(
+            DeidentifyColumns.fieldIdsFor(
+                ImmutableList.of(
+                    "__AUTOTOKENIZE__RECORD_ID__",
+                    "$.simple_field1",
+                    "$.level1_array[0].[\"level1_array_record\"].level2_simple_field.string",
+                    "$.level1_array[1].[\"level1_array_record\"].level2_array[1].string",
+                    "$.level1_array[0].[\"level1_array_record\"].level2_array[0].string",
+                    "$.level1_array[0].[\"level1_array_record\"].level2_array[1].string",
+                    "$.level1_array[1].[\"level1_array_record\"].level2_simple_field.string",
+                    "$.level1_array[1].[\"level1_array_record\"].level2_array[0].string")));
+  }
+
+  @Test
+  public void addElement_exceedsSize_returnsFalse() {
+    PartialColumnBatchAccumulator accumulator =
+        PartialColumnBatchAccumulator.withConfig(
+            NUMBER_TOKENIZE_CONFIG.toBuilder()
+                .addTransforms(
+                    ColumnTransform.newBuilder()
+                        .setColumnId("$.name")
+                        .setTransform(CRYPTO_UNWRAPPED_TRANSFORM)
+                        .build())
+                .build());
+
+    Value testValue = get1KByteString();
+    FlatRecord testRecord =
+        FlatRecord.newBuilder()
+            .setRecordId("!24")
+            .putFlatKeySchema("$.name", "$.name")
+            .putValues("$.name", testValue)
+            .build();
+
+    // Fill the accumulator till its full.
+    while (accumulator.addElement(testRecord))
+      ;
+
+    assertThat(accumulator.addElement(testRecord)).isFalse();
+    assertThat(
+            accumulator.makeBatch().get().getTable().getSerializedSize()
+                + testValue.getSerializedSize())
+        .isGreaterThan(PartialColumnBatchAccumulator.MAX_DLP_PAYLOAD_SIZE_BYTES);
+  }
+
+  private static Value get1KByteString() {
+    byte[] randomBytes = new byte[2500];
+    new Random().nextBytes(randomBytes);
+    return Value.newBuilder()
+        .setStringValue(new String(randomBytes, StandardCharsets.UTF_8))
+        .build();
+  }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-util/src/main/java/com/google/cloud/solutions/autotokenize/testing/stubs/dlp/TokenizingColPatternChecker.java
+++ b/test-util/src/main/java/com/google/cloud/solutions/autotokenize/testing/stubs/dlp/TokenizingColPatternChecker.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.testing.stubs.dlp;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.google.privacy.dlp.v2.FieldId;
+import com.google.privacy.dlp.v2.FieldTransformation;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+class TokenizingColPatternChecker {
+  private static final Pattern REGEX_SPECIAL_CHARS =
+      Pattern.compile(
+          "([\\<\\(\\[\\{\\\\\\^\\-\\=\\$\\!\\|\\]\\}\\)\\?\\*\\+\\.\\>\\\"\\']+)");
+
+  private final ImmutableSet<String> tokenizingPatterns;
+
+  public TokenizingColPatternChecker(Collection<String> fieldNames) {
+    this.tokenizingPatterns =
+        fieldNames.stream()
+            .map(TokenizingColPatternChecker::makeArrayPatternForField)
+            .collect(toImmutableSet());
+  }
+
+  public static TokenizingColPatternChecker forTransforms(
+      Collection<FieldTransformation> transformations) {
+    return new TokenizingColPatternChecker(
+        transformations.stream()
+            .map(FieldTransformation::getFieldsList)
+            .flatMap(Collection::stream)
+            .map(FieldId::getName)
+            .collect(toImmutableSet()));
+  }
+
+  public boolean isTokenizeColumn(String columnName) {
+    return tokenizingPatterns.stream()
+        .map(columnName::matches)
+        .filter(Boolean.TRUE::equals)
+        .findAny()
+        .orElse(Boolean.FALSE);
+  }
+
+  public boolean isTokenizeColumn(FieldId fieldId) {
+    return isTokenizeColumn(fieldId.getName());
+  }
+
+  private static String makeArrayPatternForField(String fieldName) {
+    return Splitter.on('.')
+        .splitToStream(fieldName)
+        .map(part -> REGEX_SPECIAL_CHARS.matcher(part).replaceAll("\\\\$0"))
+        .map(part -> part + "(?:\\[\\d+\\])?")
+        .collect(Collectors.joining("\\."));
+  }
+}

--- a/test-util/src/main/resources/avro_records/contacts_schema/jane_doe_contact_number_base64_avro_record.textpb
+++ b/test-util/src/main/resources/avro_records/contacts_schema/jane_doe_contact_number_base64_avro_record.textpb
@@ -1,0 +1,53 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
+flat_key_schema {
+  key: "$.contacts[0].[\"contact\"].number"
+  value: "$.contact_records.contacts.contact.number"
+}
+flat_key_schema {
+  key: "$.contacts[0].[\"contact\"].type"
+  value: "$.contact_records.contacts.contact.type"
+}
+flat_key_schema {
+  key: "$.contacts[1].[\"contact\"].number"
+  value: "$.contact_records.contacts.contact.number"
+}
+flat_key_schema {
+  key: "$.contacts[1].[\"contact\"].type"
+  value: "$.contact_records.contacts.contact.type"
+}
+flat_key_schema {
+  key: "$.name"
+  value: "$.contact_records.name"
+}
+values {
+  key: "$.contacts[0].[\"contact\"].encrypted_number"
+  value {
+    string_value: "AAAAAH6iVVI="
+  }
+}
+values {
+  key: "$.contacts[0].[\"contact\"].type"
+  value {
+    string_value: "WORK"
+  }
+}
+values {
+  key: "$.contacts[1].[\"contact\"].encrypted_number"
+  value {
+    string_value: "AAAAATwphNI="
+  }
+}
+values {
+  key: "$.contacts[1].[\"contact\"].type"
+  value {
+    string_value: "HOME"
+  }
+}
+values {
+  key: "$.name"
+  value {
+    string_value: "Jane Doe"
+  }
+}

--- a/test-util/src/main/resources/avro_records/contacts_schema/john_doe_contact_number_base64_avro_record.textpb
+++ b/test-util/src/main/resources/avro_records/contacts_schema/john_doe_contact_number_base64_avro_record.textpb
@@ -1,0 +1,73 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
+flat_key_schema {
+  key: "$.contacts[0].[\"contact\"].number"
+  value: "$.contact_records.contacts.contact.number"
+}
+flat_key_schema {
+  key: "$.contacts[0].[\"contact\"].type"
+  value: "$.contact_records.contacts.contact.type"
+}
+flat_key_schema {
+  key: "$.contacts[1].[\"contact\"].number"
+  value: "$.contact_records.contacts.contact.number"
+}
+flat_key_schema {
+  key: "$.contacts[1].[\"contact\"].type"
+  value: "$.contact_records.contacts.contact.type"
+}
+flat_key_schema {
+  key: "$.contacts[2].[\"contact\"].number"
+  value: "$.contact_records.contacts.contact.number"
+}
+flat_key_schema {
+  key: "$.contacts[2].[\"contact\"].type"
+  value: "$.contact_records.contacts.contact.type"
+}
+flat_key_schema {
+  key: "$.name"
+  value: "$.contact_records.name"
+}
+values {
+  key: "$.contacts[0].[\"contact\"].encrypted_number"
+  value {
+    string_value: "AAAAAVA+dYI="
+  }
+}
+values {
+  key: "$.contacts[0].[\"contact\"].type"
+  value {
+    string_value: "WORK"
+  }
+}
+values {
+  key: "$.contacts[1].[\"contact\"].encrypted_number"
+  value {
+    string_value: "AAAAAEmWAtI="
+  }
+}
+values {
+  key: "$.contacts[1].[\"contact\"].type"
+  value {
+    string_value: "HOME"
+  }
+}
+values {
+  key: "$.contacts[2].[\"contact\"].encrypted_number"
+  value {
+    string_value: "AAAAAkywFuo="
+  }
+}
+values {
+  key: "$.contacts[2].[\"contact\"].type"
+  value {
+    string_value: "MOBILE"
+  }
+}
+values {
+  key: "$.name"
+  value {
+    string_value: "John Doe"
+  }
+}

--- a/test-util/src/main/resources/avro_records/records_with_two_levels_of_arrays/simple_two_level_array_record.json
+++ b/test-util/src/main/resources/avro_records/records_with_two_levels_of_arrays/simple_two_level_array_record.json
@@ -1,0 +1,35 @@
+{
+  "simple_field1": "my simple field1",
+  "level1_array": [
+    {
+      "level1_array_record": {
+        "level2_simple_field": {
+          "string": "WORK"
+        },
+        "level2_array": [
+          {
+            "string": "element1"
+          },
+          {
+            "string": "element2"
+          }
+        ]
+      }
+    },
+    {
+      "level1_array_record": {
+        "level2_simple_field": {
+          "string": "HOME"
+        },
+        "level2_array": [
+          {
+            "string": "element3"
+          },
+          {
+            "string": "element4"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test-util/src/main/resources/avro_records/records_with_two_levels_of_arrays/two_level_arrays_schema.avsc
+++ b/test-util/src/main/resources/avro_records/records_with_two_levels_of_arrays/two_level_arrays_schema.avsc
@@ -1,0 +1,37 @@
+{
+  "type": "record",
+  "name": "multi_level_arrays",
+  "doc": "Multilevel Arrays for testing",
+  "fields": [
+    {
+      "name": "simple_field1",
+      "type": "string"
+    },
+    {
+      "name": "level1_array",
+      "type": {
+        "type": "array",
+        "items": [
+          "null",
+          {
+            "type": "record",
+            "name": "level1_array_record",
+            "fields": [
+              {
+                "name": "level2_simple_field",
+                "type": ["null", "string"]
+              },
+              {
+                "name": "level2_array",
+                "type" : {
+                  "type" : "array",
+                  "items" : ["null", "string"]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test-util/src/main/resources/flat_records/array_with_null_union_long_flat_record.textpb
+++ b/test-util/src/main/resources/flat_records/array_with_null_union_long_flat_record.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.name"
   value: "$.kylosample.name"

--- a/test-util/src/main/resources/flat_records/array_with_null_union_record_flat_record.textpb
+++ b/test-util/src/main/resources/flat_records/array_with_null_union_record_flat_record.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.name"
   value: "$.kylosample.name"

--- a/test-util/src/main/resources/flat_records/simple_field_flat_record.textpb
+++ b/test-util/src/main/resources/flat_records/simple_field_flat_record.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.registration_dttm"
   value: "$.kylosample.registration_dttm"

--- a/test-util/src/main/resources/flat_records/union_with_array_flat_record.textpb
+++ b/test-util/src/main/resources/flat_records/union_with_array_flat_record.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.last_name"
   value: "$.kylosample.last_name"

--- a/test-util/src/main/resources/flat_records/userdata_avro/record-1.textpb
+++ b/test-util/src/main/resources/flat_records/userdata_avro/record-1.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.country"
   value: "$.kylosample.country"

--- a/test-util/src/main/resources/flat_records/userdata_avro/record-2.textpb
+++ b/test-util/src/main/resources/flat_records/userdata_avro/record-2.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.country"
   value: "$.kylosample.country"

--- a/test-util/src/main/resources/flat_records/userdata_avro/record-cc-null.textpb
+++ b/test-util/src/main/resources/flat_records/userdata_avro/record-cc-null.textpb
@@ -1,3 +1,6 @@
+# proto-file: protos/src/main/proto/google/cloud/autodlp/auto_tokenize_messages.proto
+# proto-message: FlatRecord
+
 flat_key_schema {
   key: "$.country"
   value: "$.kylosample.country"

--- a/test-util/src/test/java/com/google/cloud/solutions/autotokenize/testing/stubs/dlp/TokenizingColPatternCheckerTest.java
+++ b/test-util/src/test/java/com/google/cloud/solutions/autotokenize/testing/stubs/dlp/TokenizingColPatternCheckerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.testing.stubs.dlp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.privacy.dlp.v2.FieldId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TokenizingColPatternCheckerTest {
+
+  @Test
+  public void isTokenizeColumn_singleLevelArrayElement_isTrue() {
+    TokenizingColPatternChecker testChecker =
+        new TokenizingColPatternChecker(
+            ImmutableList.of(
+                "$.level1_array.[\"level1_array_record\"].level2_simple_field.string"));
+
+    assertThat(
+            testChecker.isTokenizeColumn(
+                FieldId.newBuilder()
+                    .setName(
+                        "$.level1_array[0].[\"level1_array_record\"].level2_simple_field.string")
+                    .build()))
+        .isTrue();
+  }
+
+  @Test
+  public void isTokenizeColumn_singleLevelArrayElementNonMatchingArrayExpansion_isFalse() {
+    TokenizingColPatternChecker testChecker =
+        new TokenizingColPatternChecker(
+            ImmutableList.of(
+                "$.level1_array.[\"level1_array_record\"].level2_simple_field.string"));
+
+    assertThat(
+            testChecker.isTokenizeColumn(
+                FieldId.newBuilder()
+                    .setName("$.level1_array[0].[\"level1_array_record\"].level2_array[1].string")
+                    .build()))
+        .isFalse();
+  }
+
+  @Test
+  public void isTokenizeColumn_twoLevelArrayElement_isTrue() {
+    TokenizingColPatternChecker testChecker =
+        new TokenizingColPatternChecker(
+            ImmutableList.of("$.level1_array.[\"level1_array_record\"].level2_array.string"));
+
+    assertThat(
+            testChecker.isTokenizeColumn(
+                FieldId.newBuilder()
+                    .setName("$.level1_array[1].[\"level1_array_record\"].level2_array[1].string")
+                    .build()))
+        .isTrue();
+  }
+}


### PR DESCRIPTION
* Update DLP Array element handling 
  * DLP DeIdentifyConfig allows table column header expansion with array indexes in square brackets
* Improved test coverage
* upgrade to Gradle 7.0